### PR TITLE
Fix for ISSUE-28 We check if the basket data actually returns something

### DIFF
--- a/src/Omni/Helper/BasketHelper.php
+++ b/src/Omni/Helper/BasketHelper.php
@@ -884,7 +884,7 @@ class BasketHelper extends AbstractHelper
         $uom = $this->itemHelper->getUom($itemSku, $baseUnitOfMeasure);
         $rowTotal   = "";
         $basketData = $this->getOneListCalculation();
-        $orderLines = $basketData->getOrderLines()->getOrderLine();
+        $orderLines = $basketData ? $basketData->getOrderLines()->getOrderLine() : [];
         foreach ($orderLines as $line) {
             // @codingStandardsIgnoreLine
             if ($itemSku[0] == $line->getItemId() && $itemSku[1] == $line->getVariantId() && $uom == $line->getUomId()) {


### PR DESCRIPTION
<!---
    Thank you for contributing to LS eCommerce - Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
This fixes a problem reported in #28 .
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
A better check is done on the basket Data before the orderlines are fetched. 
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format lsretailomni/lsmag-two#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. lsretailomni/lsmag-two#28: Issue in cart when logging in 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. You start as a guest and you put something in the cart
2. Log in with an existing account
3. Log out
4. Log in again, no issues should occur.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
