### PR TITLE
Fix for ISSUE-32: We use the layout processor to implement a component in ShippingAdditional

### DIFF
--- a/src/Omni/Plugin/Checkout/Model/LayoutProcessorPlugin.php
+++ b/src/Omni/Plugin/Checkout/Model/LayoutProcessorPlugin.php
@@ -45,8 +45,7 @@ class LayoutProcessorPlugin
         LoyaltyHelper $loyaltyHelper,
         GiftCardHelper $giftCardHelper,
         LSR $lsr
-    )
-    {
+    ) {
         $this->data = $data;
         $this->loyaltyHelper = $loyaltyHelper;
         $this->giftCardHelper = $giftCardHelper;
@@ -62,8 +61,7 @@ class LayoutProcessorPlugin
     public function afterProcess(
         LayoutProcessor $subject,
         array $jsLayout
-    )
-    {
+    ) {
         if ($this->data->isCouponsEnabled('checkout') == '0') {
             unset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']['payment']['children']['afterMethods']['children']['discount']);
         }

--- a/src/Omni/Plugin/Checkout/Model/LayoutProcessorPlugin.php
+++ b/src/Omni/Plugin/Checkout/Model/LayoutProcessorPlugin.php
@@ -45,11 +45,12 @@ class LayoutProcessorPlugin
         LoyaltyHelper $loyaltyHelper,
         GiftCardHelper $giftCardHelper,
         LSR $lsr
-    ) {
-        $this->data           = $data;
-        $this->loyaltyHelper  = $loyaltyHelper;
+    )
+    {
+        $this->data = $data;
+        $this->loyaltyHelper = $loyaltyHelper;
         $this->giftCardHelper = $giftCardHelper;
-        $this->lsr               = $lsr;
+        $this->lsr = $lsr;
     }
 
     /**
@@ -61,7 +62,8 @@ class LayoutProcessorPlugin
     public function afterProcess(
         LayoutProcessor $subject,
         array $jsLayout
-    ) {
+    )
+    {
         if ($this->data->isCouponsEnabled('checkout') == '0') {
             unset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']['payment']['children']['afterMethods']['children']['discount']);
         }
@@ -73,7 +75,23 @@ class LayoutProcessorPlugin
             unset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']['payment']['children']['afterMethods']['children']['gift-card']);
         }
 
-        if(!$this->isValid()) {
+        if (isset($jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shippingAdditional']['children'])) {
+            $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']
+            ['shippingAdditional']['children']['select_store'] = ['component' => 'Ls_Omni/js/view/checkout/shipping/select-store'];
+        } else {
+            $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shippingAdditional'] =
+                [
+                    'component' => "uiComponent",
+                    'displayArea' => 'shippingAdditional',
+                    'children' => [
+                        'select_store' => [
+                            'component' => 'Ls_Omni/js/view/checkout/shipping/select-store'
+                        ]
+                    ]
+                ];
+        }
+
+        if (!$this->isValid()) {
             unset($jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']['shippingAddress']['children']['shippingAdditional']['children']['select_store']);
         }
         return $jsLayout;
@@ -85,6 +103,6 @@ class LayoutProcessorPlugin
      */
     public function isValid()
     {
-        return  $this->lsr->isLSR($this->lsr->getCurrentStoreId());
+        return $this->lsr->isLSR($this->lsr->getCurrentStoreId());
     }
 }

--- a/src/Omni/view/frontend/layout/checkout_index_index.xml
+++ b/src/Omni/view/frontend/layout/checkout_index_index.xml
@@ -16,27 +16,6 @@
                             <item name="children" xsi:type="array">
                                 <item name="steps" xsi:type="array">
                                     <item name="children" xsi:type="array">
-                                        <item name="shipping-step" xsi:type="array">
-                                            <item name="children" xsi:type="array">
-                                                <item name="shippingAddress" xsi:type="array">
-                                                    <item name="children" xsi:type="array">
-                                                        <item name="shippingAdditional" xsi:type="array">
-                                                            <item name="component" xsi:type="string">uiComponent</item>
-                                                            <item name="displayArea" xsi:type="string">
-                                                                shippingAdditional
-                                                            </item>
-                                                            <item name="children" xsi:type="array">
-                                                                <item name="select_store" xsi:type="array">
-                                                                    <item name="component" xsi:type="string">
-                                                                        Ls_Omni/js/view/checkout/shipping/select-store
-                                                                    </item>
-                                                                </item>
-                                                            </item>
-                                                        </item>
-                                                    </item>
-                                                </item>
-                                            </item>
-                                        </item>
                                         <item name="billing-step" xsi:type="array">
                                             <item name="children" xsi:type="array">
                                                 <item name="payment" xsi:type="array">


### PR DESCRIPTION

### Description (*)
This PR changes the implementation of the ShippingAdditional section in the checkout. Instead of using the layout file, we now use the layout processor. This allows other third party modules to also add components to the shippingAdditional section.

### Fixed Issues (if relevant)
1. lsretailomni/lsmag-two#32

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Install any magento version
2. Install ls retail module
3. create custom module that also uses the layout processor to add a component to the shippingAdditional section in the checkout
