### PR TITLE
Merge extension_attributes on addressInformation. When this is not do…

### DIFF
--- a/src/Omni/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/src/Omni/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -16,11 +16,11 @@
             let pickupDate = $('[name="pickup-date"]') ? $('[name="pickup-date"]').val() : '';
             let pickupTimeslot = $('[name="pickup-timeslot"]') ? $('[name="pickup-timeslot"]').val() : '';
             _.extend(payload.addressInformation, {
-                extension_attributes: {
+                extension_attributes: _.extend(payload.addressInformation.extension_attributes ,{
                     'pickup_store': $('#pickup-store').val(),
                     'pickup_date': pickupDate,
                     'pickup_timeslot': pickupTimeslot
-                }
+                })
             });
 
             return payload;


### PR DESCRIPTION
Merge extension_attributes on addressInformation. When this is done extension_attributes from other modules will be overwritten instead of being merged

<!---
    Thank you for contributing to LS eCommerce - Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
We ran into an issue where extension_attributes added by other modules on addressInformation during shipping data storage in check-out were overwritten when the payload was modified. Merging the extension_attributes instead of replacing them fixes the issue

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install module that modifies extension_attributes payload. In the example of module amasty deliverydate manager the selected delivery date and pick-up slot were not stores. (We know the module offers functions for this, but we required additional logic for this).
2. Complete an order. All the additional data should be saved on the order.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
