### PR TITLE
action child block names for cart item renderers were not unique

### DIFF
--- a/src/Omni/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/src/Omni/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -29,23 +29,23 @@
             </block>
             <block class="Ls\Omni\Block\Cart\Item\Renderer" as="simple" template="Ls_Omni::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions"
-                       name="checkout.cart.item.renderers.override.default.actions" as="actions">
+                       name="checkout.cart.item.renderers.override.simple.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit"
-                           name="checkout.cart.item.renderers.override.default.actions.edit"
+                           name="checkout.cart.item.renderers.override.simple.actions.edit"
                            template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove"
-                           name="checkout.cart.item.renderers.override.default.actions.remove"
+                           name="checkout.cart.item.renderers.override.simple.actions.remove"
                            template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>
                 </block>
             </block>
             <block class="Ls\Omni\Block\Cart\Item\Renderer" as="bundle" template="Ls_Omni::cart/item/default.phtml">
                 <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions"
-                       name="checkout.cart.item.renderers.override.default.actions" as="actions">
+                       name="checkout.cart.item.renderers.override.bundle.actions" as="actions">
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit"
-                           name="checkout.cart.item.renderers.override.default.actions.edit"
+                           name="checkout.cart.item.renderers.override.bundle.actions.edit"
                            template="Magento_Checkout::cart/item/renderer/actions/edit.phtml"/>
                     <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove"
-                           name="checkout.cart.item.renderers.override.default.actions.remove"
+                           name="checkout.cart.item.renderers.override.bundle.actions.remove"
                            template="Magento_Checkout::cart/item/renderer/actions/remove.phtml"/>
                 </block>
             </block>


### PR DESCRIPTION
### Description (*)
We ran into an issue where action blocks for cart items were not loaded. Seems like the child block names were not unique. Making them unique fixed our issue

### Manual testing scenarios (*)
1. Add product to cart, simple and/or bundle
2. Go to checkout/cart
3. Edit en remove actions should be available in cart


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
