### PR TITLE
Fix points translations

### DIFF
--- a/src/Omni/view/frontend/web/js/model/points.js
+++ b/src/Omni/view/frontend/web/js/model/points.js
@@ -1,4 +1,4 @@
-define(['jquery', 'ko', 'Magento_Checkout/js/model/quote'], function ($, ko, quote) {
+define(['jquery', 'ko', 'Magento_Checkout/js/model/quote', 'mage/translate'], function ($, ko, quote, $t) {
     "use strict";
 
     var pattern,
@@ -6,7 +6,7 @@ define(['jquery', 'ko', 'Magento_Checkout/js/model/quote'], function ($, ko, quo
         rateLabel;
 
     var extensionAttributes = quote.getTotals()().extension_attributes;
-    pattern = {single: "{point} point", plural: "{point} points"};
+    pattern = {single: $t("{point} point"), plural: $t("{point} points")};
     if (extensionAttributes && extensionAttributes.loyalty_points) {
         balance = extensionAttributes.loyalty_points.balance;
         rateLabel = extensionAttributes.loyalty_points.rateLabel;


### PR DESCRIPTION
<!---
    Thank you for contributing to LS eCommerce - Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Added translation of points label in checkout summary


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Apply loyalty points in cart
2. Navigate to checkout and check order summary
3. The label is hardcoded "points" and cannot be translated.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
